### PR TITLE
Task: SUB-10 Make field can_renew on product template

### DIFF
--- a/publishing_subscription_order/models/product.py
+++ b/publishing_subscription_order/models/product.py
@@ -13,6 +13,8 @@ class ProductTemplate(models.Model):
     subscr_number_of_days = fields.Integer('No. Of Days')
     digital_subscription = fields.Boolean(string='Is digital subscription?')
     weekday_ids = fields.Many2many('week.days', 'weekday_template_rel', 'template_id', 'weekday_id', 'Weekdays')
+    can_renew = fields.Boolean('Can Renewed?', default=False)
+    renew_product_id = fields.Many2one('product.template','Renewal Product')
 
     @api.multi
     def _get_product_accounts(self):
@@ -28,6 +30,21 @@ class ProductTemplate(models.Model):
             self.weekday_ids = [(6,0,weekdays.ids)]
         else:
             self.weekday_ids = [(6, 0, [])]
+
+    @api.model
+    def create(self, values):
+        res = super(ProductTemplate, self).create(values)
+        if res.subscription_product and values['can_renew'] and not values['renew_product_id']:
+            res.write({'renew_product_id':res.id})
+        return res
+
+    @api.onchange('can_renew','renew_product_id')
+    def onchange_renewal(self):
+        if self.subscription_product and self._origin.id:
+            if self.can_renew and not self.renew_product_id:
+                self.renew_product_id = self._origin.id or False
+            elif not self.can_renew:
+                self.renew_product_id = False
 
 class ProductCategory(models.Model):
     _inherit = 'product.category'

--- a/publishing_subscription_order/views/product_view.xml
+++ b/publishing_subscription_order/views/product_view.xml
@@ -8,14 +8,17 @@
         <field name="inherit_id" ref="account.product_template_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='properties'][last()]" position="after">
+                <separator string="Subscription" colspan="4"/>
                 <group name="enable_subscription" col="4">
                     <field name="subscription_product"/>
-                    <field name="weekday_ids" widget="many2many_tags" options="{'no_create_edit': True}" attrs="{'invisible':[('subscription_product','=',False)]}"/>
                     <field name="digital_subscription" attrs="{'invisible':[('subscription_product','=',False)]}"/>
                     <field name="number_of_issues" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}"/>
                     <field name="subscr_number_of_days" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}"/>
-                    <field name="delivery_obligation_account_id" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}"/>
-                    <field name="subscription_revenue_account_id" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}"/>
+                    <field name="delivery_obligation_account_id" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}" groups="account.group_account_user"/>
+                    <field name="subscription_revenue_account_id" attrs="{'invisible':[('subscription_product','=',False)],'required':[('subscription_product','=',True)]}" groups="account.group_account_user"/>
+                    <field name="can_renew" attrs="{'invisible':[('subscription_product','=',False)]}"/>
+                    <field name="renew_product_id" attrs="{'invisible':['|',('subscription_product','=',False),('can_renew','=',False)]}" options="{'no_create_edit': True}" domain="[('subscription_product','=',True)]"/>
+                    <field name="weekday_ids" widget="many2many_tags" options="{'no_create_edit': True}" attrs="{'invisible':[('subscription_product','=',False)]}"/>
                 </group>
             </xpath>
         </field>

--- a/publishing_subscription_order/views/sale_subscription_view.xml
+++ b/publishing_subscription_order/views/sale_subscription_view.xml
@@ -59,7 +59,7 @@
                         <group>
                             <field name="partner_id" domain="[('customer','=',True),('parent_id','=',False),('is_subscription_customer','=',True)]" context="{'search_default_customer':1, 'show_address': 1}" options='{"always_reload": True}' string="Subscriber"/>
                             <!--<field name="partner_invoice_id" groups="sale.group_delivery_invoice_address" context="{'default_type':'invoice'}" />-->
-                            <field name="partner_shipping_id" domain="[('id','child_of',partner_id)]" groups="sale.group_delivery_invoice_address" context="{'default_type':'delivery', 'show_address': 1}" options='{"always_reload": True}'/>
+                            <field name="partner_shipping_id" groups="sale.group_delivery_invoice_address" context="{'default_type':'delivery', 'show_address': 1}" options='{"always_reload": True}'/>
                         </group>
                         <group>
                             <field name="date_order" attrs="{'invisible': [('state', 'in', ['sale', 'done', 'cancel'])]}"/>
@@ -87,19 +87,20 @@
                                                    domain="[('type','!=', 'view'), ('id','child_of', medium),('subscription_categ','=',True)]"
                                                    options="{'no_open': True,'no_create': True, 'no_create_edit': True}"
                                                    attrs="{'readonly': [('subscription_cancel', '=', True)]}"/>
-                                            <!--field name="title_ids" string="Titles"
+                                            <field name="title_ids" string="Titles"
                                                    attrs="{'readonly': [('subscription_cancel', '=', True)]}"
-                                                   domain="[('parent_id','=', False),('medium','child_of', medium)]"
+                                                   domain="[('parent_id','=', False),('medium','child_of', medium),('subscription_title','=',True)]"
                                                    options="{'no_open': True,'no_create': True, 'no_create_edit': True}"
                                                    context="{'search_view_ref':'sale_advertising_order.view_advertising_issue_filter',
-                                                             'tree_view_ref':'sale_advertising_order.advertising_issue_titles_tree' }">
+                                                             'tree_view_ref':'sale_advertising_order.advertising_issue_titles_tree' }"
+                                                    required="True">
                                                 <tree create="true" edit="false" delete="true" copy="false">
                                                     <field name="name" string="Name" readonly="1"/>
                                                 </tree>
-                                            </field-->
-                                            <field name="title" string="Title"
+                                            </field>
+                                            <!--<field name="title" string="Title"
                                                    domain="[('child_ids','!=', False),('subscription_title','=', True),('medium','child_of', medium)]"
-                                                   options="{'no_open': True,'no_create': True, 'no_create_edit': True}"/>
+                                                   options="{'no_open': True,'no_create': True, 'no_create_edit': True}"/>-->
                                             <field name="product_template_id" required="1"
                                                    context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                                                    attrs="{'readonly': ['|','|','|', ('qty_invoiced', '&gt;', 0), ('procurement_ids', '!=', []),('subscription_cancel', '=', True)]}"
@@ -196,7 +197,7 @@
                                 <tree string="Sales Order Lines"  decoration-info="invoice_status=='to invoice'" decoration-muted="subscription_cancel==True">
                                     <field name="sequence" widget="handle"/>
                                     <field name="id"/>
-                                    <field name="title" />
+                                    <!--<field name="title" />-->
                                     <field name="ad_class" groups="base.group_no_one"/>
                                     <field name="product_id"
                                         attrs="{'readonly': ['|', ('qty_invoiced', '&gt;', 0), ('procurement_ids', '!=', [])]}"
@@ -523,19 +524,20 @@
                                    domain="[('type','!=', 'view'), ('id','child_of', medium),('subscription_categ','=',True)]"
                                    options="{'no_open': True,'no_create': True, 'no_create_edit': True}"
                                    attrs="{'readonly': [('subscription_cancel', '=', True)]}"/>
-                            <field name="title" string="Title"
-                                   domain="[('child_ids','!=', False),('subscription_title','=', True),('medium','child_of', medium)]"
-                                   options="{'no_open': True,'no_create': True, 'no_create_edit': True}"/>
-                            <!--<field name="title_ids" string="Titles"-->
-                                   <!--attrs="{'readonly': [('subscription_cancel', '=', True)]}"-->
-                                   <!--domain="[('parent_id','=', False),('medium','child_of', medium)]"-->
-                                   <!--options="{'no_open': True,'no_create': True, 'no_create_edit': True}"-->
-                                   <!--context="{'search_view_ref':'sale_advertising_order.view_advertising_issue_filter',-->
-                                                             <!--'tree_view_ref':'sale_advertising_order.advertising_issue_titles_tree' }">-->
-                                    <!--<tree create="true" edit="false" delete="true" copy="false">-->
-                                        <!--<field name="name" string="Name" readonly="1"/>-->
-                                    <!--</tree>-->
-                            <!--</field>-->
+                            <!--<field name="title" string="Title"-->
+                                   <!--domain="[('child_ids','!=', False),('subscription_title','=', True),('medium','child_of', medium)]"-->
+                                   <!--options="{'no_open': True,'no_create': True, 'no_create_edit': True}"/>-->
+                            <field name="title_ids" string="Titles"
+                                   attrs="{'readonly': [('subscription_cancel', '=', True)]}"
+                                   domain="[('parent_id','=', False),('medium','child_of', medium),('subscription_title','=',True)]"
+                                   options="{'no_open': True,'no_create': True, 'no_create_edit': True}"
+                                   context="{'search_view_ref':'sale_advertising_order.view_advertising_issue_filter',
+                                                             'tree_view_ref':'sale_advertising_order.advertising_issue_titles_tree' }"
+                                   required="True">
+                                    <tree create="true" edit="false" delete="true" copy="false">
+                                        <field name="name" string="Name" readonly="1"/>
+                                    </tree>
+                            </field>
                             <field name="order_id" invisible="1"/>
                             <field name="order_pricelist_id" invisible="1"/>
                             <field name="order_company_id" invisible="1"/>
@@ -628,7 +630,7 @@
                         <field name="id"/>
                         <field name="order_id" />
                         <field name="order_partner_id" />
-                        <field name="title" />
+                        <!--<field name="title" />-->
                         <field name="ad_class" />
                         <field name="product_id" />
                         <field name="layout_category_id" groups="sale.group_sale_layout"/>
@@ -784,6 +786,12 @@
                 <xpath expr="//page/field[@name='order_line']/form/group/group/field[@name='ad_class']" position="attributes">
                     <attribute name="domain">[('type','!=', 'view'), ('id','child_of', medium), ('subscription_categ','=', False)]</attribute>
                 </xpath>
+                <xpath expr="//page/field[@name='order_line']/form/group/group/field[@name='title_ids']" position="attributes">
+                    <attribute name="domain">[('parent_id','=', False),('medium','child_of', medium), ('subscription_title','=', False)]</attribute>
+                </xpath>
+                <xpath expr="//page/field[@name='order_line']/form/group/group/field[@name='title']" position="attributes">
+                    <attribute name="domain">[('parent_id','=', False),('medium','child_of', medium), ('subscription_title','=', False)]</attribute>
+                </xpath>
             </field>
         </record>
 
@@ -794,6 +802,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='ad_class']" position="attributes">
                     <attribute name="domain">[('type','!=', 'view'), ('id','child_of', medium), ('subscription_categ','=', False)]</attribute>
+                </xpath>
+                <xpath expr="//field[@name='title_ids']" position="attributes">
+                    <attribute name="domain">[('parent_id','=', False),('medium','child_of', medium), ('subscription_title','=', False)]</attribute>
+                </xpath>
+                <xpath expr="//field[@name='title']" position="attributes">
+                    <attribute name="domain">[('parent_id','=', False),('medium','child_of', medium), ('subscription_title','=', False)]</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Task : SUB-10 Make field can_renew on product template 
Task link : https://bo-test.bdu.nl/web#id=183&view_type=form&model=project.task&menu_id=96&action=142
- Renewal product added to Template.
- Title Many2many and required.
- Default order line renewal product from Template.
- Adverting categories added new domain 'subscribtion_categ = False'.
- Subscription categories domain 'subscribtion_categ = True'.
- optimized renewal cron method.
- Removed parent domain from sale delivery address.

Module: publishing_subscription_order
