### PR TITLE
additional generic filters for orderlines

### DIFF
--- a/sale_advertising_order/i18n/nl.po
+++ b/sale_advertising_order/i18n/nl.po
@@ -1727,6 +1727,11 @@ msgstr "Orderregels met de editiedatum vóór vandaag"
 
 #. module: sale_advertising_order
 #: model:ir.ui.view,arch_db:sale_advertising_order.view_order_advertising_tree
+msgid "Salesteam"
+msgstr "Verkoopteam"
+
+#. module: sale_advertising_order
+#: model:ir.ui.view,arch_db:sale_advertising_order.view_order_advertising_tree
 msgid "Order Number"
 msgstr "Ordernummer"
 

--- a/sale_advertising_order/models/sale_advertising.py
+++ b/sale_advertising_order/models/sale_advertising.py
@@ -560,6 +560,8 @@ class SaleOrderLine(models.Model):
                                           string='Advertising Customer', store=True)
     order_agency_id = fields.Many2one(related='order_id.advertising_agency', relation='res.partner',
                                           string='Advertising Agency', store=True)
+    order_team_id   = fields.Many2one(related='order_id.team_id', relation='crm.team',
+                                          string='Salesteam', store=True)
     order_pricelist_id = fields.Many2one(related='order_id.pricelist_id', relation='product.pricelist', string='Pricelist')
     order_company_id = fields.Many2one(related='order_id.company_id', relation='res.company',
                                          string='Company')

--- a/sale_advertising_order/views/sale_advertising_view.xml
+++ b/sale_advertising_order/views/sale_advertising_view.xml
@@ -1242,7 +1242,9 @@
                         <filter string="Advertiser" domain="[]" context="{'group_by':'order_advertiser_id'}"/>
                         <filter string="Agency" domain="[]" context="{'group_by':'order_agency_id'}"/>
                         <filter string="Product" domain="[]" context="{'group_by':'product_id'}"/>
+                        <filter string="Ad class" domain="[]" context="{'group_by':'ad_class'}"/>
                         <filter string="Order" domain="[]" context="{'group_by':'order_id'}"/>
+                        <filter string="Salesteam" domain="[]" context="{'group_by':'order_team_id'}"/>
                         <filter string="Salesperson" domain="[]" context="{'group_by':'salesman_id'}"/>
                         <filter string="Account Manager" icon="terp-personal" domain="[]" context="{'group_by':'partner_acc_mgr'}"/>
                         <filter string="Issue Date" icon="terp-personal" domain="[]" context="{'group_by':'issue_date'}"/>


### PR DESCRIPTION
Generic filters are:
- salesteam: needs related field and translation
- ad_class: just needs an entry in the grouping list