### PR TITLE
sale_advertising_order : actual_unit_price precision follows decimal …

### DIFF
--- a/sale_advertising_order/models/sale_advertising.py
+++ b/sale_advertising_order/models/sale_advertising.py
@@ -407,7 +407,8 @@ class SaleOrderLine(models.Model):
                 elif price_unit > 0.0 and qty > 0.0 :
                     comp_discount = round((1.0 - float(subtotal_bad) / (float(price_unit) * float(qty) + float(csa) *
                                                                         float(qty))) * 100.0, 5)
-                    unit_price = round((float(price_unit) + float(csa)) * (1 - float(comp_discount) / 100), 2)
+                    decimals=self.env['decimal.precision'].search([('name','=','Product Price')]).digits or 4
+                    unit_price = round((float(price_unit) + float(csa)) * (1 - float(comp_discount) / 100), decimals)
                 elif qty == 0.0:
                     unit_price = 0.0
                     comp_discount = 0.0


### PR DESCRIPTION
…precision according configuration instead of hard coded value.
Currently Wave2 orders (with larger quantities) show price deviations as a result of the lesser hard coded internal precision. 
Note: with quantities in hundreds and pricing with 2 decimals internal precision, hence unit pricing, should be at least 4 decimals. So decimal precision should be configured to be 4 for this change to be effective.