### PR TITLE
[IMP] make stored related field readonly

### DIFF
--- a/publishing_subscription_order/models/sale_subscription.py
+++ b/publishing_subscription_order/models/sale_subscription.py
@@ -36,7 +36,7 @@ class SaleOrder(models.Model):
     _inherit = ["sale.order"]
 
     subscription = fields.Boolean('Subscription', default=False)
-    subscription_payment_mode_id = fields.Many2one(related='partner_id.subscription_customer_payment_mode_id', relation='account.payment.mode', string='Payment method', company_dependent=True,domain=[('payment_type', '=', 'inbound')],help="Select the default subscription payment mode for this customer.", copy=False, store=True)
+    subscription_payment_mode_id = fields.Many2one(related='partner_id.subscription_customer_payment_mode_id', relation='account.payment.mode', string='Payment method', company_dependent=True,domain=[('payment_type', '=', 'inbound')],help="Select the default subscription payment mode for this customer.", copy=False, store=True, readonly=True)
     delivery_type = fields.Many2one('delivery.list.type', 'Delivery Type', default=lambda self: self.env.ref('publishing_subscription_order.delivery_list_type_regular', False) if 'params' in self._context and 'action' in self._context['params'] and self._context['params']['action'] ==  self.env.ref('publishing_subscription_order.action_orders_subscription').id else False)
 
     @api.depends('order_line.price_total', 'order_line.computed_discount', 'partner_id')


### PR DESCRIPTION
this speeds up sale order creation by several hundred percent.

The story here is that the field on res.partner this relates to is a [commercial field](https://github.com/magnuscolors/vertical-publishing/blob/10.0/publishing_subscription_order/models/res_partner.py#L91), so when you create the order with the related field not being readonly, this will generate a write on res.partner, which in turn recurses in a super inefficient way in v10 to write the values on the children. So the more children the partner has, the longer this will take.

Making the field readonly sidesteps all of this